### PR TITLE
Reduce build size

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,12 +37,11 @@
   },
   "dependencies": {
     "lodash.clamp": "^4.0.3",
-    "lodash.isarray": "^4.0.0",
     "lodash.isfunction": "^3.0.8",
     "lodash.isobject": "^3.0.2",
-    "lodash.merge": "^4.6.0",
     "lodash.range": "^3.2.0",
     "lodash.times": "^4.3.2",
+    "object-assign": "^4.1.0",
     "raf": "3.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-touch",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "React wrapper components that make touch events easy",
   "main": "./lib/index.js",
   "repository": {
@@ -36,29 +36,37 @@
     "react": "^0.14 || ^15.0"
   },
   "dependencies": {
-    "lodash": "4.6.1",
+    "lodash.clamp": "^4.0.3",
+    "lodash.isarray": "^4.0.0",
+    "lodash.isfunction": "^3.0.8",
+    "lodash.isobject": "^3.0.2",
+    "lodash.merge": "^4.6.0",
+    "lodash.range": "^3.2.0",
+    "lodash.times": "^4.3.2",
     "raf": "3.2.0"
   },
   "devDependencies": {
     "babel-cli": "6.6.4",
     "babel-eslint": "6.0.0",
     "babel-loader": "6.2.4",
+    "babel-plugin-rewire": "^1.0.0-rc-2",
     "babel-plugin-transform-class-properties": "6.6.0",
     "babel-plugin-transform-react-jsx": "6.4.0",
-    "babel-plugin-rewire": "^1.0.0-rc-2",
     "babel-preset-es2015": "6.6.0",
     "babel-preset-stage-2": "6.5.0",
-    "codecov.io": "0.1.6",
     "chai": "3.5.0",
+    "codecov.io": "0.1.6",
     "eslint": "2.4.0",
     "eslint-config-airbnb": "6.1.0",
     "eslint-plugin-react": "4.2.3",
     "istanbul": "1.0.0-alpha.2",
     "jsdom": "8.1.0",
+    "lodash.isnull": "^3.0.0",
+    "lodash.omitby": "^4.6.0",
     "mocha": "2.4.5",
     "react": "^0.14",
-    "react-dom": "^0.14",
     "react-addons-test-utils": "^0.14",
+    "react-dom": "^0.14",
     "sinon": "1.17.3",
     "webpack": "1.12.14"
   }

--- a/src/CustomGesture.react.js
+++ b/src/CustomGesture.react.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import isFunction from 'lodash/isFunction';
-import isArray from 'lodash/isArray';
-import merge from 'lodash/merge';
+import isFunction from 'lodash.isfunction';
+import isArray from 'lodash.isarray';
+import merge from 'lodash.merge';
 
 import TouchHandler from './TouchHandler';
 import computeDeltas from './computeDeltas';

--- a/src/CustomGesture.react.js
+++ b/src/CustomGesture.react.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import isFunction from 'lodash.isfunction';
-import isArray from 'lodash.isarray';
-import merge from 'lodash.merge';
+import objectAssign from 'object-assign';
 
 import TouchHandler from './TouchHandler';
 import computeDeltas from './computeDeltas';
@@ -50,7 +49,7 @@ class CustomGesture extends React.Component {
 
   handleTouchStart(touchPosition) {
     // set initial conditions for the touch event
-    this._state = merge({}, this._state, {current: touchPosition});
+    this._state = objectAssign({}, this._state, {current: touchPosition});
   }
 
   handleTouchMove(touchPosition) {
@@ -73,7 +72,7 @@ class CustomGesture extends React.Component {
       return;
     }
 
-    const gesture = isArray(config.gesture) ? config.gesture.join("") : config.gesture;
+    const gesture = Array.isArray(config.gesture) ? config.gesture.join("") : config.gesture;
     const distance = gestureLevenshtein(this._state.moves.join(""), gesture);
 
     if (distance < config.fudgeFactor) {

--- a/src/Draggable.react.js
+++ b/src/Draggable.react.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import isFunction from 'lodash/isFunction';
+import isFunction from 'lodash.isfunction';
 
 import TouchHandler from './TouchHandler';
 import computePositionStyle from './computePositionStyle';

--- a/src/Holdable.react.js
+++ b/src/Holdable.react.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import isFunction from 'lodash.isfunction';
-import merge from 'lodash.merge';
 import clamp from 'lodash.clamp';
+import objectAssign from 'object-assign';
 
 import defineHold from './defineHold';
 import TouchHandler from './TouchHandler';
@@ -74,13 +74,13 @@ class Holdable extends React.Component {
   handleTouchStart() {
     // set initial conditions for the touch event
     const initial = Date.now();
-    this.setState(merge({}, this.state, { initial, current: initial }));
+    this.setState(objectAssign({}, this.state, { initial, current: initial }));
 
     this._clearHoldProgressTimer = this._startHoldProgress(holdLength => {
       const current = Date.now();
       const _duration = (current - this.state.initial) / holdLength;
       const duration = clamp(_duration, 0, 1);
-      this.setState(merge({}, this.state, { current, duration }));
+      this.setState(objectAssign({}, this.state, { current, duration }));
 
       if (duration === 1) {
         // edge case: setTimeout ensures onholdComplete has a chance to fire

--- a/src/Holdable.react.js
+++ b/src/Holdable.react.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import isFunction from 'lodash/isFunction';
-import merge from 'lodash/merge';
-import clamp from 'lodash/clamp';
+import isFunction from 'lodash.isfunction';
+import merge from 'lodash.merge';
+import clamp from 'lodash.clamp';
 
 import defineHold from './defineHold';
 import TouchHandler from './TouchHandler';

--- a/src/Swipeable.react.js
+++ b/src/Swipeable.react.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import isFunction from 'lodash/isFunction';
-import merge from 'lodash/merge';
+import isFunction from 'lodash.isfunction';
+import merge from 'lodash.merge';
 
 import TouchHandler from './TouchHandler';
 import defineSwipe from './defineSwipe';

--- a/src/Swipeable.react.js
+++ b/src/Swipeable.react.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import isFunction from 'lodash.isfunction';
-import merge from 'lodash.merge';
+import objectAssign from 'object-assign';
 
 import TouchHandler from './TouchHandler';
 import defineSwipe from './defineSwipe';
@@ -47,14 +47,14 @@ class Swipeable extends React.Component {
   }
 
   handleTouchStart(touchPosition) {
-    this.setState(merge({}, this.state, {
+    this.setState(objectAssign({}, this.state, {
       initial: touchPosition,
       current: touchPosition,
     }));
   }
 
   handleTouchMove(touchPosition) {
-    this.setState(merge({}, this.state, { current: touchPosition }));
+    this.setState(objectAssign({}, this.state, { current: touchPosition }));
 
     DIRECTIONS.forEach(direction => {
       const name = `onSwipe${direction}`;
@@ -75,7 +75,7 @@ class Swipeable extends React.Component {
   _resetState() {
     this._touchHandler.cancelAnimationFrame();
     this._handlerFired = {};
-    this.setState(merge({}, this.state, DEFAULT_STATE));
+    this.setState(objectAssign({}, this.state, DEFAULT_STATE));
   }
 
   render() {

--- a/src/circleMath.js
+++ b/src/circleMath.js
@@ -1,4 +1,4 @@
-import range from 'lodash/range';
+import range from 'lodash.range';
 
 const DIRECTIONS = 8;
 const RESOLUTION = 128;

--- a/src/convertToDefaultsObject.js
+++ b/src/convertToDefaultsObject.js
@@ -1,5 +1,5 @@
-import isArray from 'lodash/isArray';
-import isObject from 'lodash/isObject';
+import isArray from 'lodash.isarray';
+import isObject from 'lodash.isobject';
 
 const convertToDefaultsObject = (value, mainKey='main', defaultValues={}) => {
   if (isArray(value) || !isObject(value)) {

--- a/src/convertToDefaultsObject.js
+++ b/src/convertToDefaultsObject.js
@@ -1,8 +1,7 @@
-import isArray from 'lodash.isarray';
 import isObject from 'lodash.isobject';
 
 const convertToDefaultsObject = (value, mainKey='main', defaultValues={}) => {
-  if (isArray(value) || !isObject(value)) {
+  if (Array.isArray(value) || !isObject(value)) {
     return { ...defaultValues, [mainKey]: value };
   }
   return { ...defaultValues, ...value };

--- a/src/gestureLevenshtein.js
+++ b/src/gestureLevenshtein.js
@@ -1,4 +1,4 @@
-import times from 'lodash/times';
+import times from 'lodash.times';
 import { sectorDistance } from './circleMath';
 
 const BIG_NUM = 10000;

--- a/src/tests/CustomGesture.react.spec.js
+++ b/src/tests/CustomGesture.react.spec.js
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
-import times from 'lodash/times';
+import times from 'lodash.times';
 
 import { documentEvent, renderComponent, createFakeRaf, nativeTouch } from './helpers';
 import moves from '../gestureMoves';

--- a/src/tests/Swipeable.react.spec.js
+++ b/src/tests/Swipeable.react.spec.js
@@ -3,8 +3,8 @@ import sinon from 'sinon';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
-import omitBy from 'lodash/omitBy';
-import isNull from 'lodash/isNull';
+import omitBy from 'lodash.omitby';
+import isNull from 'lodash.isnull';
 
 import { documentEvent, renderComponent, createFakeRaf, nativeTouch } from './helpers';
 import Swipeable from '../Swipeable.react';

--- a/src/tests/helpers.js
+++ b/src/tests/helpers.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
+import objectAssign from 'object-assign';
 
 export const documentEvent = (eventName, props={}) => {
-  const evt = Object.assign(document.createEvent("HTMLEvents"), props);
+  const evt = objectAssign(document.createEvent("HTMLEvents"), props);
   evt.initEvent(eventName, true, true);
   document.dispatchEvent(evt);
 };


### PR DESCRIPTION
This PR significantly reduces the built size of this library by

- Replacing `lodash` with smaller `lodash` module functions
- Replacing `lodash.merge` with `object-assign`, since the `merge` function is not being used to do deep/recursive merges
- Replacing `lodash.isArray` with `Array.isArray` which is ES5 and present in all browsers that React supports

Building our minified production app with this PR shows a reduction of almost 20KB in size.

```sh
                         Asset      Size  Chunks             Chunk Names
           chunk-manifest.json  35 bytes          [emitted]  
vendor-10916adfd6f1dd5c670e.js    328 kB       0  [emitted]  vendor
   app-8f392d91951dc65657e7.js    144 kB       1  [emitted]  app
                 manifest.json  94 bytes          [emitted]  

```
vs
```
                                   Asset      Size  Chunks             Chunk Names
           chunk-manifest.json  35 bytes          [emitted]  
vendor-297921503478f954406a.js    348 kB       0  [emitted]  vendor
   app-06143fa5107bcd68aeda.js    144 kB       1  [emitted]  app
                 manifest.json  94 bytes          [emitted]  
```
