### PR TITLE
Closes #3. Stops components passing __passThrough prop to DOM nodes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-touch",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "React wrapper components that make touch events easy",
   "main": "./lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-touch",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "React wrapper components that make touch events easy",
   "main": "./lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
     "watch:examples": "npm run build:examples -- --watch",
     "lint": "eslint src",
     "prepublish": "rm -rf lib && npm test && npm run build",
-    "test": "NODE_ENV=test mocha --compilers js:babel-register src/**/tests/*",
+    "test": "cross-env NODE_ENV=test mocha --compilers js:babel-register src/**/tests/*",
     "test:one": "npm test -- -g",
     "test:watch": "npm test -- --watch",
-    "test:cov": "NODE_ENV=test babel-node ./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha -- 'src/**/tests/*'",
+    "test:cov": "cross-env NODE_ENV=test babel-node ./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha -- 'src/**/tests/*'",
     "test:codecov": "cat ./coverage/lcov.info | ./node_modules/codecov.io/bin/codecov.io.js"
   },
   "keywords": [
@@ -54,6 +54,7 @@
     "babel-preset-stage-2": "6.5.0",
     "chai": "3.5.0",
     "codecov.io": "0.1.6",
+    "cross-env": "^5.1.1",
     "eslint": "2.4.0",
     "eslint-config-airbnb": "6.1.0",
     "eslint-plugin-react": "4.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-touch",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "React wrapper components that make touch events easy",
   "main": "./lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -36,32 +36,34 @@
   },
   "homepage": "https://github.com/leonaves/react-touch",
   "peerDependencies": {
-    "react": "^0.14 || ^15.0"
+    "react": "^0.14.9 || ^15.3.0"
   },
   "dependencies": {
     "lodash": "4.6.1",
+    "prop-types": "^15.5.7",
     "raf": "3.2.0"
   },
   "devDependencies": {
     "babel-cli": "6.6.4",
     "babel-eslint": "6.0.0",
     "babel-loader": "6.2.4",
+    "babel-plugin-rewire": "^1.0.0-rc-2",
     "babel-plugin-transform-class-properties": "6.6.0",
     "babel-plugin-transform-react-jsx": "6.4.0",
-    "babel-plugin-rewire": "^1.0.0-rc-2",
     "babel-preset-es2015": "6.6.0",
     "babel-preset-stage-2": "6.5.0",
-    "codecov.io": "0.1.6",
     "chai": "3.5.0",
+    "codecov.io": "0.1.6",
     "eslint": "2.4.0",
     "eslint-config-airbnb": "6.1.0",
     "eslint-plugin-react": "4.2.3",
     "istanbul": "1.0.0-alpha.2",
     "jsdom": "8.1.0",
     "mocha": "2.4.5",
+    "prop-types": "^15.5.10",
     "react": "^0.14",
-    "react-dom": "^0.14",
     "react-addons-test-utils": "^0.14",
+    "react-dom": "^0.14",
     "sinon": "1.17.3",
     "webpack": "1.12.14"
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./lib/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/phil303/react-touch"
+    "url": "https://github.com/leonaves/react-touch"
   },
   "scripts": {
     "build": "babel src --out-dir lib",
@@ -26,12 +26,15 @@
     "react-touch",
     "touch"
   ],
-  "author": "Phil Aquilina <philaquilina@gmail.com> (http://github.com/phil303)",
+  "author": "Phil Aquilina",
+  "contributors": [
+    "Leon Aves <me@leonaves.com> (https://github.com/leonaves)"
+  ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/phil303/react-touch/issues"
+    "url": "https://github.com/leonaves/react-touch/issues"
   },
-  "homepage": "https://github.com/phil303/react-touch",
+  "homepage": "https://github.com/leonaves/react-touch",
   "peerDependencies": {
     "react": "^0.14 || ^15.0"
   },

--- a/src/CustomGesture.react.js
+++ b/src/CustomGesture.react.js
@@ -94,7 +94,9 @@ class CustomGesture extends React.Component {
       ...this._touchHandler.listeners(child, onTouchStart, onMouseDown),
     };
 
-    if (typeof child.type !== 'string') props.__passThrough = __passThrough;
+    if (child.type.propTypes && child.type.propTypes.hasOwnProperty('__passThrough')) {
+      props.__passThrough = __passThrough;
+    }
 
     return React.cloneElement(React.Children.only(child), props);
   }

--- a/src/CustomGesture.react.js
+++ b/src/CustomGesture.react.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { PropTypes as T } from 'prop-types';
 import isFunction from 'lodash/isFunction';
 import isArray from 'lodash/isArray';
 import merge from 'lodash/merge';
@@ -9,7 +10,6 @@ import gestureLevenshtein from './gestureLevenshtein';
 import convertToDefaultsObject from './convertToDefaultsObject';
 import { createSectors, computeSectorIdx } from './circleMath';
 
-const T = React.PropTypes;
 
 const INITIAL_STATE = { current: null, moves: [] };
 const DEFAULT_CONFIG = { fudgeFactor: 5, minMoves: 8, gesture: "" };

--- a/src/CustomGesture.react.js
+++ b/src/CustomGesture.react.js
@@ -90,11 +90,13 @@ class CustomGesture extends React.Component {
   render() {
     const { onTouchStart, onMouseDown, children, __passThrough } = this.props;
     const child = isFunction(children) ? children(__passThrough) : children;
-
-    return React.cloneElement(React.Children.only(child), {
-      __passThrough,
+    const props = {
       ...this._touchHandler.listeners(child, onTouchStart, onMouseDown),
-    });
+    };
+
+    if (typeof child.type !== 'string') props.__passThrough = __passThrough;
+
+    return React.cloneElement(React.Children.only(child), props);
   }
 }
 

--- a/src/Draggable.react.js
+++ b/src/Draggable.react.js
@@ -66,7 +66,9 @@ class Draggable extends React.Component {
       ...this._touchHandler.listeners(child, onTouchStart, onMouseDown),
     };
 
-    if (typeof child.type !== 'string') props.__passThrough = passThrough;
+    if (child.type.propTypes && child.type.propTypes.hasOwnProperty('__passThrough')) {
+      props.__passThrough = passThrough;
+    }
 
     return React.cloneElement(React.Children.only(child), props);
   }

--- a/src/Draggable.react.js
+++ b/src/Draggable.react.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { PropTypes as T } from 'prop-types';
 import isFunction from 'lodash/isFunction';
 
 import TouchHandler from './TouchHandler';
@@ -6,7 +7,6 @@ import computePositionStyle from './computePositionStyle';
 import computeDeltas from './computeDeltas';
 
 
-const T = React.PropTypes;
 const ZERO_DELTAS = { dx: 0, dy: 0 };
 const DEFAULT_TOUCH = { initial: null, current: null, deltas: ZERO_DELTAS };
 

--- a/src/Draggable.react.js
+++ b/src/Draggable.react.js
@@ -62,11 +62,13 @@ class Draggable extends React.Component {
     const { onTouchStart, onMouseDown, children, __passThrough } = this.props;
     const passThrough = { ...__passThrough, ...this.passThroughState() };
     const child = isFunction(children) ? children({ ...passThrough }) : children;
-
-    return React.cloneElement(React.Children.only(child), {
-      __passThrough: passThrough,
+    const props = {
       ...this._touchHandler.listeners(child, onTouchStart, onMouseDown),
-    });
+    };
+
+    if (typeof child.type !== 'string') props.__passThrough = passThrough;
+
+    return React.cloneElement(React.Children.only(child), props);
   }
 }
 

--- a/src/Holdable.react.js
+++ b/src/Holdable.react.js
@@ -107,7 +107,9 @@ class Holdable extends React.Component {
       ...this._touchHandler.listeners(child, onTouchStart, onMouseDown),
     };
 
-    if (typeof child.type !== 'string') props.__passThrough = passThrough;
+    if (child.type.propTypes && child.type.propTypes.hasOwnProperty('__passThrough')) {
+      props.__passThrough = passThrough;
+    }
 
     return React.cloneElement(React.Children.only(child), props);
   }

--- a/src/Holdable.react.js
+++ b/src/Holdable.react.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { PropTypes as T } from 'prop-types';
 import isFunction from 'lodash/isFunction';
 import merge from 'lodash/merge';
 import clamp from 'lodash/clamp';
@@ -7,7 +8,6 @@ import defineHold from './defineHold';
 import TouchHandler from './TouchHandler';
 
 
-const T = React.PropTypes;
 const DEFAULT_HOLD = { initial: null, current: null, duration: 0 };
 
 class Holdable extends React.Component {

--- a/src/Holdable.react.js
+++ b/src/Holdable.react.js
@@ -103,11 +103,13 @@ class Holdable extends React.Component {
     const { onTouchStart, onMouseDown, children, __passThrough } = this.props;
     const passThrough = { ...__passThrough, ...this.passThroughState() };
     const child = isFunction(children) ? children({ ...passThrough }) : children;
-
-    return React.cloneElement(React.Children.only(child), {
-      __passThrough: passThrough,
+    const props = {
       ...this._touchHandler.listeners(child, onTouchStart, onMouseDown),
-    });
+    };
+
+    if (typeof child.type !== 'string') props.__passThrough = passThrough;
+
+    return React.cloneElement(React.Children.only(child), props);
   }
 }
 

--- a/src/Swipeable.react.js
+++ b/src/Swipeable.react.js
@@ -86,7 +86,9 @@ class Swipeable extends React.Component {
       ...this._touchHandler.listeners(child, onTouchStart, onMouseDown),
     };
 
-    if (typeof child.type !== 'string') props.__passThrough = passThrough;
+    if (child.type.propTypes && child.type.propTypes.hasOwnProperty('__passThrough')) {
+      props.__passThrough = passThrough;
+    }
 
     return React.cloneElement(React.Children.only(child), props);
   }

--- a/src/Swipeable.react.js
+++ b/src/Swipeable.react.js
@@ -82,11 +82,13 @@ class Swipeable extends React.Component {
     const { onTouchStart, onMouseDown, children, __passThrough } = this.props;
     const passThrough = { ...__passThrough, ...this.passThroughState() };
     const child = isFunction(children) ? children({ ...passThrough }) : children;
-
-    return React.cloneElement(React.Children.only(child), {
-      __passThrough: passThrough,
+    const props = {
       ...this._touchHandler.listeners(child, onTouchStart, onMouseDown),
-    });
+    };
+
+    if (typeof child.type !== 'string') props.__passThrough = passThrough;
+
+    return React.cloneElement(React.Children.only(child), props);
   }
 }
 

--- a/src/Swipeable.react.js
+++ b/src/Swipeable.react.js
@@ -1,12 +1,11 @@
 import React from 'react';
+import { PropTypes as T } from 'prop-types';
 import isFunction from 'lodash/isFunction';
 import merge from 'lodash/merge';
 
 import TouchHandler from './TouchHandler';
 import defineSwipe from './defineSwipe';
 
-
-const T = React.PropTypes;
 const DIRECTIONS = ['Left', 'Right', 'Up', 'Down'];
 const ZERO_DELTAS = { dx: 0, dy: 0 };
 const DEFAULT_STATE = { initial: null, current: null, deltas: ZERO_DELTAS };

--- a/src/tests/CustomGesture.react.spec.js
+++ b/src/tests/CustomGesture.react.spec.js
@@ -96,7 +96,27 @@ describe("CustomGesture", () => {
     expect(output.type).to.be.equal('div');
   });
 
-  it("should pass the correct props to its child", () => {
+  it("should pass the correct props to nested react-touch components", () => {
+    const renderer = TestUtils.createRenderer();
+    renderer.render(
+      <CustomGesture>
+        <CustomGesture>
+          <ExampleComponent />
+        </CustomGesture>
+      </CustomGesture>
+    );
+    const output = renderer.getRenderOutput();
+    expect(output.props).to.have.keys([
+      '__passThrough',
+      'children',
+      'config',
+      'onGesture',
+      'onMouseDown',
+      'onTouchStart',
+    ]);
+  });
+
+  it("should not pass custom props to its children", () => {
     const renderer = TestUtils.createRenderer();
     renderer.render(
       <CustomGesture>
@@ -104,7 +124,7 @@ describe("CustomGesture", () => {
       </CustomGesture>
     );
     const output = renderer.getRenderOutput();
-    expect(output.props).to.have.keys(['__passThrough', 'onMouseDown', 'onTouchStart']);
+    expect(output.props).to.have.keys(['onMouseDown', 'onTouchStart']);
   });
 
   it("should not pass custom props down to DOM nodes", () => {

--- a/src/tests/CustomGesture.react.spec.js
+++ b/src/tests/CustomGesture.react.spec.js
@@ -5,7 +5,7 @@ import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
 import times from 'lodash/times';
 
-import { documentEvent, renderComponent, createFakeRaf, nativeTouch } from './helpers';
+import { documentEvent, renderComponent, createFakeRaf, nativeTouch, ExampleComponent } from './helpers';
 import moves from '../gestureMoves';
 import CustomGesture from '../CustomGesture.react';
 import TouchHandler from '../TouchHandler';
@@ -99,11 +99,22 @@ describe("CustomGesture", () => {
     const renderer = TestUtils.createRenderer();
     renderer.render(
       <CustomGesture>
-        <div></div>
+        <ExampleComponent></ExampleComponent>
       </CustomGesture>
     );
     const output = renderer.getRenderOutput();
     expect(output.props).to.have.keys(['__passThrough', 'onMouseDown', 'onTouchStart']);
+  });
+
+  it("should not pass custom props down to DOM nodes", () => {
+    const renderer = TestUtils.createRenderer();
+    renderer.render(
+      <CustomGesture>
+        <div></div>
+      </CustomGesture>
+    );
+    const output = renderer.getRenderOutput();
+    expect(output.props).to.have.keys(['onMouseDown', 'onTouchStart']);
   });
 
   it("should remove listeners when the component unmounts", () => {

--- a/src/tests/CustomGesture.react.spec.js
+++ b/src/tests/CustomGesture.react.spec.js
@@ -5,7 +5,8 @@ import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
 import times from 'lodash/times';
 
-import { documentEvent, renderComponent, createFakeRaf, nativeTouch, ExampleComponent } from './helpers';
+import { documentEvent, renderComponent, createFakeRaf,
+  nativeTouch, ExampleComponent } from './helpers';
 import moves from '../gestureMoves';
 import CustomGesture from '../CustomGesture.react';
 import TouchHandler from '../TouchHandler';
@@ -99,7 +100,7 @@ describe("CustomGesture", () => {
     const renderer = TestUtils.createRenderer();
     renderer.render(
       <CustomGesture>
-        <ExampleComponent></ExampleComponent>
+        <ExampleComponent />
       </CustomGesture>
     );
     const output = renderer.getRenderOutput();

--- a/src/tests/Draggable.react.spec.js
+++ b/src/tests/Draggable.react.spec.js
@@ -124,7 +124,27 @@ describe("Draggable", () => {
     expect(output.type).to.be.equal('div');
   });
 
-  it("should pass the correct props to its child", () => {
+  it("should pass the correct props to nested react-touch components", () => {
+    const renderer = TestUtils.createRenderer();
+    renderer.render(
+      <Draggable position={{translateX: 100, translateY: 100}}>
+        <Draggable position={{translateX: 100, translateY: 100}}>
+          <ExampleComponent />
+        </Draggable>
+      </Draggable>
+    );
+    const output = renderer.getRenderOutput();
+    expect(output.props).to.have.keys([
+      '__passThrough',
+      'children',
+      'position',
+      'onMouseDown',
+      'onTouchStart',
+    ]);
+  });
+
+
+  it("should not pass custom props to its children", () => {
     const renderer = TestUtils.createRenderer();
     renderer.render(
       <Draggable position={{translateX: 100, translateY: 100}}>
@@ -132,7 +152,7 @@ describe("Draggable", () => {
       </Draggable>
     );
     const output = renderer.getRenderOutput();
-    expect(output.props).to.have.keys(['__passThrough', 'onMouseDown', 'onTouchStart']);
+    expect(output.props).to.have.keys(['onMouseDown', 'onTouchStart']);
   });
 
   it("should not pass custom props down to DOM nodes", () => {

--- a/src/tests/Draggable.react.spec.js
+++ b/src/tests/Draggable.react.spec.js
@@ -4,7 +4,8 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
 
-import { documentEvent, renderComponent, createFakeRaf, nativeTouch, ExampleComponent } from './helpers';
+import { documentEvent, renderComponent, createFakeRaf,
+  nativeTouch, ExampleComponent } from './helpers';
 import Draggable from '../Draggable.react';
 import TouchHandler from '../TouchHandler';
 
@@ -127,7 +128,7 @@ describe("Draggable", () => {
     const renderer = TestUtils.createRenderer();
     renderer.render(
       <Draggable position={{translateX: 100, translateY: 100}}>
-        <ExampleComponent></ExampleComponent>
+        <ExampleComponent />
       </Draggable>
     );
     const output = renderer.getRenderOutput();

--- a/src/tests/Draggable.react.spec.js
+++ b/src/tests/Draggable.react.spec.js
@@ -4,7 +4,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
 
-import { documentEvent, renderComponent, createFakeRaf, nativeTouch } from './helpers';
+import { documentEvent, renderComponent, createFakeRaf, nativeTouch, ExampleComponent } from './helpers';
 import Draggable from '../Draggable.react';
 import TouchHandler from '../TouchHandler';
 
@@ -127,10 +127,21 @@ describe("Draggable", () => {
     const renderer = TestUtils.createRenderer();
     renderer.render(
       <Draggable position={{translateX: 100, translateY: 100}}>
-        <div></div>
+        <ExampleComponent></ExampleComponent>
       </Draggable>
     );
     const output = renderer.getRenderOutput();
     expect(output.props).to.have.keys(['__passThrough', 'onMouseDown', 'onTouchStart']);
+  });
+
+  it("should not pass custom props down to DOM nodes", () => {
+    const renderer = TestUtils.createRenderer();
+    renderer.render(
+      <Draggable position={{translateX: 100, translateY: 100}}>
+        <div></div>
+      </Draggable>
+    );
+    const output = renderer.getRenderOutput();
+    expect(output.props).to.have.keys(['onMouseDown', 'onTouchStart']);
   });
 });

--- a/src/tests/Holdable.react.spec.js
+++ b/src/tests/Holdable.react.spec.js
@@ -143,12 +143,30 @@ describe("Holdable", () => {
     expect(output.type).to.be.equal('div');
   });
 
-  it("should pass the correct props to its child", () => {
+  it("should pass the correct props to nested react-touch components", () => {
+    const renderer = TestUtils.createRenderer();
+    renderer.render(<Holdable>
+      <Holdable><div></div></Holdable>
+    </Holdable>);
+    const output = renderer.getRenderOutput();
+    expect(output.props).to.have.keys([
+      '__passThrough',
+      'children',
+      'config',
+      'onMouseDown',
+      'onTouchStart',
+      'onHoldComplete',
+      'onHoldProgress',
+    ]);
+  });
+
+  it("should not pass custom props to its children", () => {
     const renderer = TestUtils.createRenderer();
     renderer.render(<Holdable><ExampleComponent /></Holdable>);
     const output = renderer.getRenderOutput();
-    expect(output.props).to.have.keys(['__passThrough', 'onMouseDown', 'onTouchStart']);
+    expect(output.props).to.have.keys(['onMouseDown', 'onTouchStart']);
   });
+
 
   it("should not pass custom props down to DOM nodes", () => {
     const renderer = TestUtils.createRenderer();

--- a/src/tests/Holdable.react.spec.js
+++ b/src/tests/Holdable.react.spec.js
@@ -4,7 +4,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
 
-import { documentEvent, renderComponent } from './helpers';
+import { documentEvent, renderComponent, ExampleComponent } from './helpers';
 import Holdable from '../Holdable.react';
 import defineHold from '../defineHold';
 
@@ -145,9 +145,16 @@ describe("Holdable", () => {
 
   it("should pass the correct props to its child", () => {
     const renderer = TestUtils.createRenderer();
-    renderer.render(<Holdable><div></div></Holdable>);
+    renderer.render(<Holdable><ExampleComponent></ExampleComponent></Holdable>);
     const output = renderer.getRenderOutput();
     expect(output.props).to.have.keys(['__passThrough', 'onMouseDown', 'onTouchStart']);
+  });
+
+  it("should not pass custom props down to DOM nodes", () => {
+    const renderer = TestUtils.createRenderer();
+    renderer.render(<Holdable><div></div></Holdable>);
+    const output = renderer.getRenderOutput();
+    expect(output.props).to.have.keys(['onMouseDown', 'onTouchStart']);
   });
 
   it("should remove timers and listeners when the component unmounts", () => {

--- a/src/tests/Holdable.react.spec.js
+++ b/src/tests/Holdable.react.spec.js
@@ -145,7 +145,7 @@ describe("Holdable", () => {
 
   it("should pass the correct props to its child", () => {
     const renderer = TestUtils.createRenderer();
-    renderer.render(<Holdable><ExampleComponent></ExampleComponent></Holdable>);
+    renderer.render(<Holdable><ExampleComponent /></Holdable>);
     const output = renderer.getRenderOutput();
     expect(output.props).to.have.keys(['__passThrough', 'onMouseDown', 'onTouchStart']);
   });

--- a/src/tests/Swipeable.react.spec.js
+++ b/src/tests/Swipeable.react.spec.js
@@ -77,11 +77,26 @@ describe("Swipeable", () => {
     expect(output.type).to.be.equal('div');
   });
 
-  it("should pass the correct props to its child", () => {
+  it("should pass the correct props to nested react-touch components", () => {
+    const renderer = TestUtils.createRenderer();
+    renderer.render(<Swipeable>
+      <Swipeable><div></div></Swipeable>
+    </Swipeable>);
+    const output = renderer.getRenderOutput();
+    expect(output.props).to.have.keys([
+      '__passThrough',
+      'children',
+      'config',
+      'onMouseDown',
+      'onTouchStart',
+    ]);
+  });
+
+  it("should not pass custom props to its children", () => {
     const renderer = TestUtils.createRenderer();
     renderer.render(<Swipeable><ExampleComponent /></Swipeable>);
     const output = renderer.getRenderOutput();
-    expect(output.props).to.have.keys(['__passThrough', 'onMouseDown', 'onTouchStart']);
+    expect(output.props).to.have.keys(['onMouseDown', 'onTouchStart']);
   });
 
   it("should not pass custom props down to DOM nodes", () => {

--- a/src/tests/Swipeable.react.spec.js
+++ b/src/tests/Swipeable.react.spec.js
@@ -6,7 +6,8 @@ import TestUtils from 'react-addons-test-utils';
 import omitBy from 'lodash/omitBy';
 import isNull from 'lodash/isNull';
 
-import { documentEvent, renderComponent, createFakeRaf, nativeTouch, ExampleComponent } from './helpers';
+import { documentEvent, renderComponent, createFakeRaf,
+  nativeTouch, ExampleComponent } from './helpers';
 import Swipeable from '../Swipeable.react';
 import defineSwipe from '../defineSwipe';
 import TouchHandler from '../TouchHandler';
@@ -78,7 +79,7 @@ describe("Swipeable", () => {
 
   it("should pass the correct props to its child", () => {
     const renderer = TestUtils.createRenderer();
-    renderer.render(<Swipeable><ExampleComponent></ExampleComponent></Swipeable>);
+    renderer.render(<Swipeable><ExampleComponent /></Swipeable>);
     const output = renderer.getRenderOutput();
     expect(output.props).to.have.keys(['__passThrough', 'onMouseDown', 'onTouchStart']);
   });

--- a/src/tests/Swipeable.react.spec.js
+++ b/src/tests/Swipeable.react.spec.js
@@ -6,7 +6,7 @@ import TestUtils from 'react-addons-test-utils';
 import omitBy from 'lodash/omitBy';
 import isNull from 'lodash/isNull';
 
-import { documentEvent, renderComponent, createFakeRaf, nativeTouch } from './helpers';
+import { documentEvent, renderComponent, createFakeRaf, nativeTouch, ExampleComponent } from './helpers';
 import Swipeable from '../Swipeable.react';
 import defineSwipe from '../defineSwipe';
 import TouchHandler from '../TouchHandler';
@@ -78,9 +78,16 @@ describe("Swipeable", () => {
 
   it("should pass the correct props to its child", () => {
     const renderer = TestUtils.createRenderer();
-    renderer.render(<Swipeable><div></div></Swipeable>);
+    renderer.render(<Swipeable><ExampleComponent></ExampleComponent></Swipeable>);
     const output = renderer.getRenderOutput();
     expect(output.props).to.have.keys(['__passThrough', 'onMouseDown', 'onTouchStart']);
+  });
+
+  it("should not pass custom props down to DOM nodes", () => {
+    const renderer = TestUtils.createRenderer();
+    renderer.render(<Swipeable><div></div></Swipeable>);
+    const output = renderer.getRenderOutput();
+    expect(output.props).to.have.keys(['onMouseDown', 'onTouchStart']);
   });
 
   it("should remove listeners when the component unmounts", () => {

--- a/src/tests/helpers.js
+++ b/src/tests/helpers.js
@@ -12,7 +12,7 @@ export const renderComponent = component => {
   return props => TestUtils.renderIntoDocument(_component(props, <div></div>));
 };
 
-export const ExampleComponent = (props) => <div></div>;
+export const ExampleComponent = () => <div></div>;
 
 export const nativeTouch = (x, y) => ({touches: [{ clientX: x, clientY: y }]});
 

--- a/src/tests/helpers.js
+++ b/src/tests/helpers.js
@@ -12,6 +12,8 @@ export const renderComponent = component => {
   return props => TestUtils.renderIntoDocument(_component(props, <div></div>));
 };
 
+export const ExampleComponent = (props) => <div></div>;
+
 export const nativeTouch = (x, y) => ({touches: [{ clientX: x, clientY: y }]});
 
 export const createFakeRaf = () => {


### PR DESCRIPTION
As noted in #3. The custom `__passThrough` prop that enables nested react-touch component to pass down delta props etc. was causing warnings to be emitted when react-touch components directly wrapped DOM nodes, as it is not a valid property of DOM nodes. The changes in this PR stop this property being passed if the child is a DOM node (i.e. it's `type` property is of type string). This should keep the existing functionality while stopping this warning. I have also added tests for the new functionality.